### PR TITLE
BREAKING CHANGE: fix(sprintf): null terminate and fix return value

### DIFF
--- a/inc/writer.h
+++ b/inc/writer.h
@@ -53,6 +53,7 @@ typedef struct	s_writer_string_state
 {
 	char	*str_ptr;
 	ssize_t	maximum;
+	size_t	actually_written;
 }				t_writer_string_state;
 void			writer_string_write(t_writer *self, char *str, size_t length);
 

--- a/src/ft_sprintf.c
+++ b/src/ft_sprintf.c
@@ -19,13 +19,18 @@ ssize_t		ft_vsnprintf(char *dest, ssize_t capacity, char *fmt, va_list vlist)
 {
 	t_writer_string_state	st;
 	t_writer				writer;
+	ssize_t					ret;
 
-	st.maximum = capacity;
+	st.maximum = capacity > 0 ? capacity - 1 : capacity;
 	st.str_ptr = dest;
+	st.actually_written = 0;
 	std_memset(&writer, 0, sizeof(t_writer));
 	writer.state = (void*)&st;
 	writer.write = &writer_string_write;
-	return (ft_vwprintf(&writer, fmt, vlist));
+	ret = ft_vwprintf(&writer, fmt, vlist);
+	if (capacity != 0)
+		dest[st.actually_written] = '\0';
+	return (ret);
 }
 
 ssize_t		ft_vsprintf(char *dest, char *fmt, va_list vlist)

--- a/src/writer.c
+++ b/src/writer.c
@@ -81,15 +81,17 @@ void	writer_string_write(t_writer *self, char *str, size_t length)
 	size_t					to_write;
 
 	state = (t_writer_string_state*)self->state;
-	if (self->written + length > (size_t)state->maximum && state->maximum > 0)
+	self->written += length;
+	if ((state->actually_written + length > (size_t)state->maximum)
+		&& state->maximum >= 0)
 	{
-		to_write = state->maximum - self->written;
-		std_memcpy(state->str_ptr + self->written, str, to_write);
-		self->written += to_write;
+		to_write = state->maximum - state->actually_written;
+		std_memcpy(state->str_ptr + state->actually_written, str, to_write);
+		state->actually_written += to_write;
 	}
 	else
 	{
-		std_memcpy(state->str_ptr + self->written, str, length);
-		self->written += length;
+		std_memcpy(state->str_ptr + state->actually_written, str, length);
+		state->actually_written += length;
 	}
 }

--- a/test/spec/sprintf.spec.c
+++ b/test/spec/sprintf.spec.c
@@ -1,0 +1,54 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        ::::::::            */
+/*   sprintf.spec.c                                     :+:    :+:            */
+/*                                                     +:+                    */
+/*   By: nloomans <nloomans@student.codam.nl>         +#+                     */
+/*                                                   +#+                      */
+/*   Created: 2019/08/26 12:41:52 by nloomans       #+#    #+#                */
+/*   Updated: 2019/08/26 12:41:52 by nloomans      ########   odam.nl         */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <criterion/criterion.h>
+#include "ft_printf.h"
+
+Test(sprintf, adds_a_null_terminator) {
+	char dest[9] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+	cr_expect_eq(ft_sprintf(dest, "12345678"), 8);
+	cr_expect_str_eq(dest, "12345678");
+}
+
+Test(sprintf, adds_a_null_terminator_empty_string) {
+	char dest[9] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+	cr_expect_eq(ft_sprintf(dest, ""), 0);
+	cr_expect_str_eq(dest, "");
+}
+
+Test(snprintf, adds_a_null_terminator) {
+	char dest[9] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+	cr_expect_eq(ft_snprintf(dest, 9, "12345678"), 8);
+	cr_expect_str_eq(dest, "12345678");
+}
+
+Test(snprintf, adds_a_null_terminator_empty_string) {
+	char dest[9] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+	cr_expect_eq(ft_snprintf(dest, 9, ""), 0);
+	cr_expect_str_eq(dest, "");
+}
+
+Test(snprintf, adds_a_null_terminator_when_truncating) {
+	char dest[9] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+	cr_expect_eq(ft_snprintf(dest, 9, "1234567890"), 10);
+	cr_expect_str_eq(dest, "12345678");
+}
+
+Test(snprintf, prints_nothing_when_n_is_0) {
+	char dest[9] = {'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A'};
+	cr_expect_eq(ft_snprintf(dest, 0, "123456789"), 9);
+	cr_expect_eq(dest[0], 'A');
+}
+
+Test(snprintf, prints_nothing_when_null_ptr) {
+	cr_expect_eq(ft_snprintf(NULL, 0, "123456789"), 9);
+}


### PR DESCRIPTION
This fixes the following cases where sprintf / snprintf didn't follow
the standard:

sprintf:
- A null character is written at the end of the characters written; it
  is not counted as part of the returned value.

snprintf:
- If n is zero, nothing is written, and s may be a null pointer.
- Otherwise, output characters beyond the n-1st are discarded rather
  than being written to the array, and a null character is written at
  the end of the characters actually written into the array.
- The snprintf function returns the number of characters that would
  have been written had n been sufficiently large, not counting the
  terminating null character.